### PR TITLE
fix: duplicate threads issue, new status transmission

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -7,9 +7,9 @@ RegisterNetEvent('ox:playerLoaded', function()
         if data then
             for k,v in pairs(data) do
                 Status.new(k, v)
-                StartStatusThread()
-                StartUpdateThread()
             end
+            StartStatusThread()
+            StartUpdateThread()
         end
     end)
 end)

--- a/server/class/player.lua
+++ b/server/class/player.lua
@@ -45,7 +45,7 @@ end
 function CStatus:newStatus(status, amount)
     if not self.status[status] then
         self.status[status] = amount
-        local client = lib.callback.await('status:newStatus', self.source, status, amount)
+        local client = lib.callback.await('status:createNew', self.source, {name = status, amount = amount})
         if not client then print('[ERROR] Failed to create new status: '..status..' for player: '..self.source) end
         return true
     else


### PR DESCRIPTION
This moves the threads out of the status iteration, so single threads are created instead of per status.